### PR TITLE
Remove workaround buggy simd_fmax in LLVM6

### DIFF
--- a/src/api/ops/vector_float_min_max.rs
+++ b/src/api/ops/vector_float_min_max.rs
@@ -19,16 +19,8 @@ macro_rules! impl_ops_vector_float_min_max {
             /// the input vector lanes.
             #[inline]
             pub fn max(self, x: Self) -> Self {
-                // FIXME: https://github.com/gnzlbg/packed_simd/issues/7
-                // use codegen::llvm::simd_fmin;
-                // unsafe { Simd(simd_fmin(self.0, x.0)) }
-                let mut r = self;
-                for i in 0..$id::lanes() {
-                    let a = self.extract(i);
-                    let b = x.extract(i);
-                    r = r.replace(i, a.max(b))
-                }
-                r
+                use codegen::llvm::simd_fmax;
+                unsafe { Simd(simd_fmax(self.0, x.0)) }
             }
         }
         #[cfg(test)]

--- a/src/codegen/llvm.rs
+++ b/src/codegen/llvm.rs
@@ -89,10 +89,8 @@ extern "platform-intrinsic" {
     crate fn simd_select<M, T>(m: M, a: T, b: T) -> T;
 
     crate fn simd_fmin<T>(a: T, b: T) -> T;
-    // FIXME: https://github.com/gnzlbg/packed_simd/issues/7
-    // crate fn simd_fmax<T>(a: T, b: T) -> T;
+    crate fn simd_fmax<T>(a: T, b: T) -> T;
 
     crate fn simd_fsqrt<T>(a: T) -> T;
-    #[allow(dead_code)]
     crate fn simd_fma<T>(a: T, b: T, c: T) -> T;
 }


### PR DESCRIPTION
Closes #7 .