### PR TITLE
Add same size float from int implementations

### DIFF
--- a/src/v128.rs
+++ b/src/v128.rs
@@ -40,7 +40,7 @@ impl_u!([u32; 4]: u32x4, m32x4 | x0, x1, x2, x3 |
         /// A 128-bit vector with 4 `u32` lanes.
 );
 impl_f!([f32; 4]: f32x4, m32x4 | x0, x1, x2, x3 |
-        From: i8x4, u8x4, i16x4, u16x4 |
+        From: i8x4, u8x4, i16x4, u16x4, i32x4, u32x4 |
         /// A 128-bit vector with 4 `f32` lanes.
 );
 impl_m!([m32; 4]: m32x4 | i32 | x0, x1, x2, x3 |
@@ -57,7 +57,7 @@ impl_u!([u64; 2]: u64x2, m64x2 | x0, x1 |
         /// A 128-bit vector with 2 `u64` lanes.
 );
 impl_f!([f64; 2]: f64x2, m64x2 | x0, x1 |
-        From: i8x2, u8x2, i16x2, u16x2, i32x2, u32x2, f32x2 |
+        From: i8x2, u8x2, i16x2, u16x2, i32x2, u32x2, i64x2, u64x2, f32x2 |
         /// A 128-bit vector with 2 `f64` lanes.
 );
 impl_m!([m64; 2]: m64x2 | i64 | x0, x1 |

--- a/src/v256.rs
+++ b/src/v256.rs
@@ -46,7 +46,7 @@ impl_u!([u32; 8]: u32x8, m32x8 | x0, x1, x2, x3, x4, x5, x6, x7 |
         /// A 256-bit vector with 8 `u32` lanes.
 );
 impl_f!([f32; 8]: f32x8, m32x8 | x0, x1, x2, x3, x4, x5, x6, x7 |
-        From: i8x8, u8x8, i16x8, u16x8 |
+        From: i8x8, u8x8, i16x8, u16x8, i32x8, u32x8 |
         /// A 256-bit vector with 8 `f32` lanes.
 );
 impl_m!([m32; 8]: m32x8 | i32 | x0, x1, x2, x3, x4, x5, x6, x7 |
@@ -63,7 +63,7 @@ impl_u!([u64; 4]: u64x4, m64x4 | x0, x1, x2, x3 |
         /// A 256-bit vector with 4 `u64` lanes.
 );
 impl_f!([f64; 4]: f64x4, m64x4 | x0, x1, x2, x3 |
-        From: i8x4, u8x4, i16x4, u16x4, i32x4, u32x4, f32x4 |
+        From: i8x4, u8x4, i16x4, u16x4, i32x4, u32x4, i64x4, u64x4, f32x4 |
         /// A 256-bit vector with 4 `f64` lanes.
 );
 impl_m!([m64; 4]: m64x4 | i64 | x0, x1, x2, x3 |

--- a/src/v512.rs
+++ b/src/v512.rs
@@ -58,7 +58,7 @@ impl_u!([u32; 16]: u32x16, m32x16 |
 );
 impl_f!([f32; 16]: f32x16, m32x16 |
         x0, x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15 |
-        From: i8x16, u8x16, i16x16, u16x16 |
+        From: i8x16, u8x16, i16x16, u16x16, i32x16, u32x16 |
         /// A 512-bit vector with 16 `f32` lanes.
 );
 impl_m!([m32; 16]: m32x16 | i32 |
@@ -76,7 +76,7 @@ impl_u!([u64; 8]: u64x8, m64x8 | x0, x1, x2, x3, x4, x5, x6, x7 |
         /// A 512-bit vector with 8 `u64` lanes.
 );
 impl_f!([f64; 8]: f64x8, m64x8 | x0, x1, x2, x3, x4, x5, x6, x7 |
-        From: i8x8, u8x8, i16x8, u16x8, i32x8, u32x8, f32x8 |
+        From: i8x8, u8x8, i16x8, u16x8, i32x8, u32x8, i64x8, u64x8, f32x8 |
         /// A 512-bit vector with 8 `f64` lanes.
 );
 impl_m!([m64; 8]: m64x8 | i64 | x0, x1, x2, x3, x4, x5, x6, x7 |

--- a/src/v64.rs
+++ b/src/v64.rs
@@ -41,7 +41,7 @@ impl_m!([m32; 2]: m32x2 | i32 | x0, x1 |
         /// A 64-bit vector mask with 2 `m32` lanes.
 );
 impl_f!([f32; 2]: f32x2, m32x2 | x0, x1 |
-        From: i8x2, u8x2, i16x2, u16x2 |
+        From: i8x2, u8x2, i16x2, u16x2, i32x2, u32x2 |
         /// A 64-bit vector with 2 `f32` lanes.
 );
 


### PR DESCRIPTION
When porting rand from nightly std to packed_simd, I ran against a few missing float from int `From` implementations. `f32x*` from `u32x*` and `f64x*` from `u64x*`. See https://github.com/rust-lang-nursery/rand/blob/379ee2e6b46d20326eb666e67a027a8ceccd9082/src/distributions/utils.rs#L266

I understand these are controversial, as an `u32` can hold numbers an `f32` can't represent. Is it even specified where such values are rounded to? The standard library doesn't have such a `From` implementation, but we can get the cast by using `as`. For simd `From` seems the only option, or using a custom function.

I suppose for simd it makes more sense to have these `From` implementations, because it allows converting between integers en floats while keeping the same vector width.

cc @TheIronBorn 